### PR TITLE
Missing import

### DIFF
--- a/custom_components/chitubox_printer/config_flow.py
+++ b/custom_components/chitubox_printer/config_flow.py
@@ -2,6 +2,7 @@
 
 import logging
 import socket
+import re
 from typing import Any, Optional
 
 import homeassistant.helpers.config_validation as cv


### PR DESCRIPTION
I tried to setup my Elegoo Saturn 4 Ultra 16K, but the configuration failed with an unknown error. I checked the logs and this import was missing. After adding it and restarted home assistant, it worked perfectly and now I can see the printer information as you can see in the screenshot.

![printer](https://github.com/user-attachments/assets/5bfb9b7b-dc4f-4907-aa2e-b93013ec76dc)
